### PR TITLE
#62 hタグの処理を変更。

### DIFF
--- a/mod_header.go
+++ b/mod_header.go
@@ -1,7 +1,6 @@
 package gomarkdown
 
 import (
-	"strconv"
 	"strings"
 )
 
@@ -11,20 +10,24 @@ func (convData *convertedData) isHeader() bool {
 	return line != "" && strings.Trim(line, "#") == ""
 }
 
+var headText = "123456"
+
 // convHeader ...
 func (convData *convertedData) convHeader() {
 	// <h1> - <h6>
 	var text []string
 	convData.markdownLines[0] = strings.Trim(convData.markdownLines[0], " ")
 	h := strings.Count(strings.Split(convData.markdownLines[0], " ")[0], "#")
-	text = append(text, "<h")
-	text = append(text, strconv.Itoa(h))
-	text = append(text, ">")
-	text = append(text, convData.markdownLines[0][h+1:])
-	text = append(text, "</h")
-	text = append(text, strconv.Itoa(h))
-	text = append(text, ">")
-	convData.markdownLines[0] = strings.Join(text, "")
+	if h <= 6 && h >= 1 {
+		text = append(text, "<h")
+		text = append(text, headText[h-1:h])
+		text = append(text, ">")
+		text = append(text, convData.markdownLines[0][h+1:])
+		text = append(text, "</h")
+		text = append(text, headText[h-1:h])
+		text = append(text, ">")
+		convData.markdownLines[0] = strings.Join(text, "")
+	}
 
 	// inline
 	convData.inlineConv()


### PR DESCRIPTION
#62 配列のほうが若干速いかも？
```
var headText = "123456"
```
と
```
var headText = [6]string{"1","2"....}
```